### PR TITLE
Filter posts

### DIFF
--- a/.github/workflows/Deploy.yml
+++ b/.github/workflows/Deploy.yml
@@ -27,19 +27,11 @@ jobs:
         with:
           version: 1.7
 
-      # Get changed files. The changed files will be used to inspect what Pluto
-      # notebooks changed so they're built to HTML. Store the files into a space separated varaible
-      - id: files
-        uses: jitterbit/get-changed-files@v1
-        env:
-          CHANGED_FILES: steps.files.outputs.all
-
       # Build modified Pluto files and move files to the appropriate locations
-      # At the moment, each file is rebuilt, so it needs to be improved.
       - name: export-pluto
         run: |
           mkdir -p notebooks/html;
-          julia ${GITHUB_WORKSPACE}/.github/workflows/build_notebooks.jl ${{ steps.files.outputs.added_modified }}
+          julia ${GITHUB_WORKSPACE}/.github/workflows/build_notebooks.jl build-all
         
         
       # NOTE

--- a/.github/workflows/build_notebooks.jl
+++ b/.github/workflows/build_notebooks.jl
@@ -1,5 +1,7 @@
 # This script is used to build *modified* Julia/Pluto notebooks stored under the `notebooks`
 # directory and export them to HTML files stored under `notebooks/html`.
+#
+# To build all notebooks, pass "build-all" as the first argument
 
 import Pkg;
 Pkg.add("Pluto");
@@ -15,6 +17,10 @@ nb_dir = "notebooks";
 
 # The files are passed as arguments
 all_files = ARGS;
+
+if length(ARGS) > 0 && ARGS[1] == "build-all"
+    all_files = readdir(nb_dir; join=true);
+end
 
 # Match Julia files stored strictly under `notebooks/` directory. It ignores
 # any subdirectory under notebooks

--- a/utils.jl
+++ b/utils.jl
@@ -184,8 +184,13 @@ Get a list of years inside the `posts` directory
 function get_post_years(dir = "posts")
     # List of subfiles/subdirectories AND files
     sfiles = readdir(dir)
+    
+    # Get directories only
+    directories = filter(sfile -> isdir(joinpath(dir, sfile)), sfiles)
 
-    return parse.(Int64, filter(sfile -> isdir(joinpath(dir, sfile)), sfiles))
+    # Return "numeric" directories (i.e., directories that can be parsed into a number)
+    # For example, "2022" is a numeric directory but "_2022" is not
+    return tryparse.(Int64, directories)
 end
 
 """


### PR DESCRIPTION
- Generate posts that are stored under a numeric folder. For example, posts stored under `"posts/2022"` will be published but not `"posts/_2022"`.
- Build all notebooks when deploying