### PR TITLE
Fix resume PDF viewer on non-production hosts

### DIFF
--- a/resume.md
+++ b/resume.md
@@ -8,20 +8,30 @@ cover=true
 <div id="adobe-dc-view" style="height:1100px; width=2760px"></div>
 <script src="https://documentservices.adobe.com/view-sdk/viewer.js"></script>
 <script type="text/javascript">
-	document.addEventListener("adobe_dc_view_sdk.ready", function(){ 
-		var adobeDCView = new AdobeDC.View({clientId: "676d9d7756714b6ba13a6025f9f1be32", divId: "adobe-dc-view"});
-		adobeDCView.previewFile({
-			content:{location: {url: "/assets/resume.pdf"}},
-			metaData:{fileName: "resume.pdf"}
-		},
-		{
-	  	embedMode: "SIZED_CONTAINER",
-			defaultViewMode: "FIT_WIDTH",
-			showFullScreen: true,
-			showDownloadPDF: true,
-			exitPDFViewerType: "CLOSE",
-	  });
-	});
+	var isProd = window.location.hostname === "aalbaali.github.io";
+
+	if (isProd) {
+		document.addEventListener("adobe_dc_view_sdk.ready", function(){ 
+			var adobeDCView = new AdobeDC.View({clientId: "676d9d7756714b6ba13a6025f9f1be32", divId: "adobe-dc-view"});
+			adobeDCView.previewFile({
+				content:{location: {url: "/assets/resume.pdf"}},
+				metaData:{fileName: "resume.pdf"}
+			},
+			{
+		  	embedMode: "SIZED_CONTAINER",
+				defaultViewMode: "FIT_WIDTH",
+				showFullScreen: true,
+				showDownloadPDF: true,
+				exitPDFViewerType: "CLOSE",
+		  });
+		});
+	} else {
+		// Adobe's Client ID is only allowlisted for the production domain, so
+		// non-prod hosts (localhost, LAN IPs, etc.) fall back to the browser's
+		// native PDF viewer instead of hitting a domain-authorization error.
+		document.getElementById("adobe-dc-view").innerHTML =
+			'<iframe src="/assets/resume.pdf" width="100%" height="1100px" style="border:none;"></iframe>';
+	}
 </script>
 ~~~
 


### PR DESCRIPTION
## Summary
- Adobe's PDF Embed API Client ID for the resume page is only allowlisted for `aalbaali.github.io`, so previewing `/resume/` on `localhost` (or any LAN IP) hit `This application domain ... is not authorized ...`.
- `resume.md` now checks `window.location.hostname`: on the production domain it uses the existing Adobe embed unchanged; everywhere else it falls back to a plain `<iframe src="/assets/resume.pdf">`, which every browser renders natively with no domain restriction.

## Test plan
- [x] `julia --project=Project.toml -e 'using Pkg; Pkg.instantiate(); using Franklin; serve()'` locally, visited `http://localhost:8000/resume/` — PDF renders via the iframe fallback, no Adobe error, content matches the resume.
- [ ] After merge, visit `https://aalbaali.github.io/resume/` and confirm the Adobe-embedded viewer still renders as before (unchanged code path).